### PR TITLE
fix: Prevent tabbing into closed dialog content

### DIFF
--- a/side-drawer.js
+++ b/side-drawer.js
@@ -29,6 +29,7 @@ dialog {
     --side-drawer-transition,
     transform 0.25s ease-out
   );
+  visibility: hidden;
 }
 
 /* putting this here in case this is ever fixed:
@@ -54,6 +55,10 @@ dialog::backdrop {
     --side-drawer-overlay-transition,
     opacity linear 0.25s
   );
+}
+
+dialog[open] {
+  visibility: visible;
 }
 
 :host([open]) dialog[open],


### PR DESCRIPTION
This makes it so you don't tab into the drawer's contents when it is closed.